### PR TITLE
Add python dep to fix deasync install error.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,8 +2,9 @@ FROM node:17-buster-slim AS base
 
 MAINTAINER togglecorp info@togglecorp.com
 
-RUN apt update -y \
-    && apt install -y --no-install-recommends git bash
+RUN apt-get update -y \
+    && apt-get install -y --no-install-recommends \
+        git bash python3 g++ make
 
 WORKDIR /code
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,7 +3,7 @@ version: '3.3'
 services:
   react:
     build: .
-    command: sh -c 'yarn install && yarn start'
+    command: sh -c 'yarn install --frozen-lockfile && yarn start'
     build:
       context: ./
       target: base


### PR DESCRIPTION
- Addresses deasync install error. https://github.com/bmatcuk/eslint-plugin-postcss-modules/issues/19

## Changes

* Add python, g++, make dep on Dockerfile.

## This PR doesn't introduce any:

- [x] temporary files, auto-generated files or secret keys
- [x] build works
- [x] eslint issues
- [x] typescript issues
- [x] codegen errors
- [x] `console.log` meant for debugging
- [x] typos
- [x] unwanted comments
- [x] conflict markers
